### PR TITLE
Mb/device bus checks

### DIFF
--- a/src/algorithms/sequential_algorithm.jl
+++ b/src/algorithms/sequential_algorithm.jl
@@ -21,8 +21,9 @@ function build_main_problem!(
     sys::PSY.System,
 )
     branch_models_dict = keys(PSI.get_branch_models(template))
+    device_models_dict = keys(PSI.get_device_models(template))
     if :TwoTerminalHVDCLine ∈ branch_models_dict ||
-       :TwoTerminalHVDCLine ∈ branch_models_dict
+       :TwoTerminalVSCDCLine ∈ branch_models_dict
         has_hvdc = true
     else
         has_hvdc = false
@@ -31,6 +32,20 @@ function build_main_problem!(
         subsystem_buses = PSY.get_components(PSY.ACBus, sys; subsystem_name=k)
         subsystem_bus_nos = [PSY.get_number(b) for b in subsystem_buses]
         container.subproblem_bus_map[k] = subsystem_bus_nos
+        subsystem_static_injectors =
+            PSY.get_components(PSY.StaticInjection, sys; subsystem_name=k)
+        subsystem_buses = PSY.get_components(PSY.ACBus, sys; subsystem_name=k)
+        for si in subsystem_static_injectors
+            if Symbol(typeof(si)) ∈ device_models_dict
+                if !(PSY.get_bus(si) ∈ subsystem_buses)
+                    throw(
+                        IS.ConflictingInputsError(
+                            "static injector $(PSY.get_name(si)) is in subsystem $k but the bus it is attached to is not. Check your data inputs.",
+                        ),
+                    )
+                end
+            end
+        end
         subsystem_hvdcs = PSY.get_components(
             Union{PSY.TwoTerminalHVDCLine, PSY.TwoTerminalVSCDCLine},
             sys;

--- a/test/test_hvdc.jl
+++ b/test/test_hvdc.jl
@@ -1,54 +1,120 @@
-# HVDC spans subsystems but is not modeled (build suceeds)
-sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
-area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
-make_subsystems!(sys, area_subsystem_map)
-hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
-PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
-template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
-problem = DecisionModel(
-    MultiRegionProblem,
-    template_uc2,
-    sys;
-    name="UC_Subsystem",
-    optimizer=optimizer_with_attributes(HiGHS.Optimizer),
-)
-build_out = build!(problem; output_dir=mktempdir())
-@test build_out == PowerSimulations.ModelBuildStatus.BUILT
+@testset "HVDC spans subsystems but is not modeled (build suceeds)" begin
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
+    make_subsystems!(sys, area_subsystem_map)
+    hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
+    template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
+    problem = DecisionModel(
+        MultiRegionProblem,
+        template_uc2,
+        sys;
+        name="UC_Subsystem",
+        optimizer=optimizer_with_attributes(HiGHS.Optimizer),
+    )
+    @test build!(problem; output_dir=mktempdir()) == PowerSimulations.ModelBuildStatus.BUILT
+end
 
-# HVDC spans subsystems and is modeled (build fails)
-sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
-area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
-make_subsystems!(sys, area_subsystem_map)
-hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
-PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
-template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
-set_device_model!(template_uc2, TwoTerminalHVDCLine, HVDCTwoTerminalLossless)
-problem = DecisionModel(
-    MultiRegionProblem,
-    template_uc2,
-    sys;
-    name="UC_Subsystem",
-    optimizer=optimizer_with_attributes(HiGHS.Optimizer),
-)
-build_out = build!(problem; output_dir=mktempdir())
-@test build_out == PowerSimulations.ModelBuildStatus.FAILED
+@testset "HVDC spans subsystems and is modeled (build fails)" begin
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
+    make_subsystems!(sys, area_subsystem_map)
+    hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
+    template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
+    set_device_model!(template_uc2, TwoTerminalHVDCLine, HVDCTwoTerminalLossless)
+    problem = DecisionModel(
+        MultiRegionProblem,
+        template_uc2,
+        sys;
+        name="UC_Subsystem",
+        optimizer=optimizer_with_attributes(HiGHS.Optimizer),
+    )
+    build_out = build!(problem; output_dir=mktempdir())
+    @test build_out == PowerSimulations.ModelBuildStatus.FAILED
+end
 
-# HVDC spans subsystems and is modeled but both terminal buses belong to same subsytem (build suceeds)
-sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
-area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
-make_subsystems!(sys, area_subsystem_map)
-hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
-PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
-PowerSystems.remove_component_from_subsystem!(sys, "b", hvdc.arc.to)
-PowerSystems.add_component_to_subsystem!(sys, "a", hvdc.arc.to)
-template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
-set_device_model!(template_uc2, TwoTerminalHVDCLine, HVDCTwoTerminalLossless)
-problem = DecisionModel(
-    MultiRegionProblem,
-    template_uc2,
-    sys;
-    name="UC_Subsystem",
-    optimizer=optimizer_with_attributes(HiGHS.Optimizer),
-)
-build_out = build!(problem; output_dir=mktempdir())
-@test build_out == PowerSimulations.ModelBuildStatus.BUILT
+@testset "HVDC spans subsystems and is modeled but both terminal buses belong to same subsytem (build suceeds)" begin
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
+    make_subsystems!(sys, area_subsystem_map)
+    hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
+    PowerSystems.remove_component_from_subsystem!(sys, "b", hvdc.arc.to)
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc.arc.to)
+    template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
+    set_device_model!(template_uc2, TwoTerminalHVDCLine, HVDCTwoTerminalLossless)
+    problem = DecisionModel(
+        MultiRegionProblem,
+        template_uc2,
+        sys;
+        name="UC_Subsystem",
+        optimizer=optimizer_with_attributes(HiGHS.Optimizer),
+    )
+    build_out = build!(problem; output_dir=mktempdir())
+    @test build_out == PowerSimulations.ModelBuildStatus.BUILT
+end
+
+@testset "HVDC spans subsystems and is modeled but both terminal buses belong to same subsytem (build suceeds)" begin
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
+    make_subsystems!(sys, area_subsystem_map)
+    hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
+    PowerSystems.remove_component_from_subsystem!(sys, "b", hvdc.arc.to)
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc.arc.to)
+    template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
+    set_device_model!(template_uc2, TwoTerminalHVDCLine, HVDCTwoTerminalLossless)
+    problem = DecisionModel(
+        MultiRegionProblem,
+        template_uc2,
+        sys;
+        name="UC_Subsystem",
+        optimizer=optimizer_with_attributes(HiGHS.Optimizer),
+    )
+    build_out = build!(problem; output_dir=mktempdir())
+    @test build_out == PowerSimulations.ModelBuildStatus.BUILT
+end
+
+@testset "HVDC spans subsystems and is modeled but both terminal buses belong to same subsytem (build suceeds)" begin
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
+    make_subsystems!(sys, area_subsystem_map)
+    hvdc = get_component(TwoTerminalHVDCLine, sys, "DC1")
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc)
+    PowerSystems.remove_component_from_subsystem!(sys, "b", hvdc.arc.to)
+    PowerSystems.add_component_to_subsystem!(sys, "a", hvdc.arc.to)
+    template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
+    set_device_model!(template_uc2, TwoTerminalHVDCLine, HVDCTwoTerminalLossless)
+    problem = DecisionModel(
+        MultiRegionProblem,
+        template_uc2,
+        sys;
+        name="UC_Subsystem",
+        optimizer=optimizer_with_attributes(HiGHS.Optimizer),
+    )
+    build_out = build!(problem; output_dir=mktempdir())
+    @test build_out == PowerSimulations.ModelBuildStatus.BUILT
+end
+
+@testset "Modeled component belongs to different subsystem than attached bus (build fails)" begin
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "b")
+    a_1 = get_component(Area, sys, "1")
+    b_chifa = get_component(ACBus, sys, "Chifa")
+    set_area!(b_chifa, a_1)
+    make_subsystems!(sys, area_subsystem_map)
+    PowerSystems.remove_component_from_subsystem!(sys, "a", b_chifa)
+    PowerSystems.add_component_to_subsystem!(sys, "b", b_chifa)
+    template_uc2 = MultiProblemTemplate(NetworkModel(SplitAreaPTDFPowerModel), ["a", "b"])
+    set_device_model!(template_uc2, PowerLoad, StaticPowerLoad)
+    problem = DecisionModel(
+        MultiRegionProblem,
+        template_uc2,
+        sys;
+        name="UC_Subsystem",
+        optimizer=optimizer_with_attributes(HiGHS.Optimizer),
+    )
+    build_out = build!(problem; output_dir=mktempdir())
+    @test build_out == PowerSimulations.ModelBuildStatus.FAILED
+end

--- a/test/test_vertical_passing.jl
+++ b/test/test_vertical_passing.jl
@@ -142,11 +142,16 @@ end
 # NOTE - open issue for results processing (this is only testing a single value at t=0): https://github.com/NREL-Sienna/PowerSimulations.jl/issues/1307
 # We can manually go in and grab the results from the container to test all 5 values: 
 param = sim.models.decision_models[2].internal.container.parameters
-keys_param = collect(keys(param))
-state_estimation_injection = param[keys_param[2]].parameter_array
+state_estimation_injection =
+    param[InfrastructureSystems.Optimization.ParameterKey{
+        PowerSimulationsDecomposition.StateEstimationInjections,
+        ACBus,
+    }(
+        "",
+    )].parameter_array
 expr = sim.models.decision_models[1].internal.container.expressions
-keys_expr = collect(keys(expr))
-active_power_balance = expr[keys_expr[7]]
+active_power_balance =
+    expr[InfrastructureSystems.Optimization.ExpressionKey{ActivePowerBalance, ACBus}("")]
 for b_number in [get_number(x) for x in get_components(ACBus, sys)]
     apb = value.(active_power_balance[b_number, :]).data
     sei = state_estimation_injection[string(b_number), :].data


### PR DESCRIPTION
Adds a check that devices that are modeled belong to the same subsystem as the bus they are attached to. This will lead to unexpected results and should not be allowed. 