### PR TITLE
Add coordination algorithms

### DIFF
--- a/src/PowerSimulationsDecomposition.jl
+++ b/src/PowerSimulationsDecomposition.jl
@@ -12,7 +12,7 @@ export CoordinationAlgorithm
 export NoCoordination
 export CostCurveCoordination
 export ShadowPriceCoordination
-export ADMMCoordination
+# export ADMMCoordination
 
 import PowerSimulations
 import PowerNetworkMatrices

--- a/src/PowerSimulationsDecomposition.jl
+++ b/src/PowerSimulationsDecomposition.jl
@@ -7,6 +7,13 @@ export SplitAreaPTDFPowerModel
 export StaticBranchUnboundedStateEstimation
 export NetworkFlowConstraintStateEstimation
 
+export get_coordination
+export CoordinationAlgorithm
+export NoCoordination
+export CostCurveCoordination
+export ShadowPriceCoordination
+export ADMMCoordination
+
 import PowerSimulations
 import PowerNetworkMatrices
 import PowerSystems
@@ -40,14 +47,19 @@ include("core/mpi_info.jl")
 include("core/parameters.jl")
 include("core/auxiliary_variables.jl")
 include("core/constraints.jl")
-
+include("core/coordination_algorithms.jl")
 include("multiproblem_template.jl")
 include("multi_optimization_container.jl")
+include("core/coordination_algorithms_methods.jl")
 include("algorithms/sequential_algorithm.jl")
 include("algorithms/mpi_parallel_algorithm.jl")
+include("algorithms/coordination/no_coordination.jl")
+include("algorithms/coordination/cost_curve_coordination.jl")
+include("algorithms/coordination/shadow_price_coordination.jl")
+include("algorithms/coordination/admm_coordination.jl")
+
 include("problems/multi_region_problem.jl")
 include("models/network_models.jl")
 include("models/branch_models.jl")
 include("print.jl")
-
 end

--- a/src/algorithms/coordination/cost_curve_coordination.jl
+++ b/src/algorithms/coordination/cost_curve_coordination.jl
@@ -1,0 +1,526 @@
+const _RELIEF_PENALTY = 1.0e7
+const _LOWER_BOUND_RELAXATION = -1.0e4
+const _INFEASIBLE_COST = 1.0e6
+const _NUM_DIRECTIONS = 2
+const _PRICE_TIGHTEN = 0.001
+
+const _NETWORK_FLOW_KEY = ISOPT.ConstraintKey(
+    PSI.NetworkFlowConstraint, PSY.MonitoredLine, "",
+)
+const _FLOW_VARIABLE_KEY = ISOPT.VariableKey(
+    PSI.FlowActivePowerVariable, PSY.MonitoredLine, "",
+)
+
+Base.@kwdef mutable struct CostCurveCoordination <: CoordinationAlgorithm
+    coordinated_lines::Vector{String}
+    coordinated_regions::Vector{String} = String[]
+    num_segments::Int = 41
+    check_range_rate::Float64 = 0.1
+    cost_curve::Dict{Tuple{String, String}, Vector{Tuple{Float64, Float64}}} =
+        Dict{Tuple{String, String}, Vector{Tuple{Float64, Float64}}}()
+    flow_contribution::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    own_flow::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    relief_used::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    shadow_price::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    offset::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    step_index::Int = 0
+end
+
+_relief_index(line::String, seg::Int, dir::Int) = "$(line)_$(seg)_$(dir)"
+
+function _is_coordinated_region(algo::CostCurveCoordination, subproblem_id::String)
+    isempty(algo.coordinated_regions) && return true
+    return subproblem_id in algo.coordinated_regions
+end
+
+function _coordination_N(algo::CostCurveCoordination)
+    n = length(algo.coordinated_regions)
+    n <= 1 && return 0
+    return min(n - 1, _NUM_DIRECTIONS)
+end
+
+function _coordinated_lines_in_subproblem(
+    algo::CostCurveCoordination,
+    subproblem::PSI.OptimizationContainer,
+)
+    haskey(subproblem.variables, _FLOW_VARIABLE_KEY) || return String[]
+    available = axes(subproblem.variables[_FLOW_VARIABLE_KEY])[1]
+    return [l for l in algo.coordinated_lines if l in available]
+end
+
+function initialize_coordination!(
+    algo::CostCurveCoordination,
+    subproblem::PSI.OptimizationContainer,
+    sys::PSY.System,
+)
+    length(PSI.get_time_steps(subproblem)) == 1 || return
+    haskey(subproblem.variables, _FLOW_VARIABLE_KEY) || return
+    haskey(subproblem.constraints, _NETWORK_FLOW_KEY) || return
+
+    coord_lines = _coordinated_lines_in_subproblem(algo, subproblem)
+    isempty(coord_lines) && return
+
+    segments = 1:algo.num_segments
+    directions = 1:_NUM_DIRECTIONS
+
+    relief_indices = String[
+        _relief_index(l, s, d)
+        for l in coord_lines, s in segments, d in directions
+    ] |> vec
+
+    relief = PSI.add_variable_container!(
+        subproblem,
+        Relief(),
+        PSY.MonitoredLine,
+        relief_indices,
+        PSI.get_time_steps(subproblem);
+        meta = "",
+    )
+
+    jump_model = PSI.get_jump_model(subproblem)
+    flow_array = subproblem.variables[_FLOW_VARIABLE_KEY]
+    net_flow_con_array = subproblem.constraints[_NETWORK_FLOW_KEY]
+
+    for l in coord_lines, s in segments, d in directions
+        idx = _relief_index(l, s, d)
+        relief[idx, 1] = JuMP.@variable(jump_model, base_name = "Relief_{$(d)_$(s),$(l)}")
+        JuMP.set_lower_bound(relief[idx, 1], 0.0)
+        JuMP.set_upper_bound(relief[idx, 1], 0.0)
+        JuMP.set_objective_coefficient(jump_model, relief[idx, 1], _RELIEF_PENALTY)
+    end
+
+    for l in coord_lines
+        flow_var = flow_array[l, 1]
+        net_flow_con = net_flow_con_array[l, 1]
+        JuMP.set_lower_bound(flow_var, _LOWER_BOUND_RELAXATION)
+        for s in segments, d in directions
+            idx = _relief_index(l, s, d)
+            # JuMP.set_normalized_coefficient(net_flow_con, relief[idx, 1], 1.0)
+            JuMP.set_normalized_coefficient(net_flow_con, relief[idx, 1], -1.0)
+        end
+    end
+    return
+end
+
+function update_coordination!(
+    algo::CostCurveCoordination,
+    container::MultiOptimizationContainer,
+    sys::PSY.System,
+    subproblem_id::String,
+)
+    subproblem = get_subproblem(container, subproblem_id)
+    length(PSI.get_time_steps(subproblem)) == 1 || return
+
+    ptdf = PSI.VirtualPTDF(sys; tol = 1e-4, max_cache_size = 10000)
+    bus_numbers = get(container.subproblem_bus_map, subproblem_id, Int[])
+    isempty(bus_numbers) && return
+    bus_balance_expr = PSI.get_expression(subproblem, PSI.ActivePowerBalance(), PSY.ACBus)
+    bus_balance_values = JuMP.value.(bus_balance_expr)
+
+    relief_key = ISOPT.VariableKey(Relief, PSY.MonitoredLine, "")
+    relief = haskey(subproblem.variables, relief_key) ?
+        subproblem.variables[relief_key] : nothing
+
+    local_coord_lines = _coordinated_lines_in_subproblem(algo, subproblem)
+    participates = _is_coordinated_region(algo, subproblem_id)
+
+    for l in algo.coordinated_lines
+        contrib = 0.0
+        for bus_no in bus_numbers
+            contrib += ptdf[l, bus_no] * bus_balance_values[bus_no, 1]
+        end
+        algo.flow_contribution[(subproblem_id, l)] = contrib
+
+        if participates && (l in local_coord_lines)
+            flow_var = subproblem.variables[_FLOW_VARIABLE_KEY][l, 1]
+            of = JuMP.value(flow_var)
+            algo.own_flow[(subproblem_id, l)] = of
+
+            ru = 0.0
+            if relief !== nothing
+                for d in 1:_NUM_DIRECTIONS, s in 1:algo.num_segments
+                    idx = _relief_index(l, s, d)
+                    idx in axes(relief)[1] || continue
+                    ru += JuMP.value(relief[idx, 1])
+                end
+            end
+            algo.relief_used[(subproblem_id, l)] = ru
+
+            price = NaN
+            if haskey(subproblem.constraints, _NETWORK_FLOW_KEY) &&
+               l in axes(subproblem.constraints[_NETWORK_FLOW_KEY])[1]
+                con = subproblem.constraints[_NETWORK_FLOW_KEY][l, 1]
+                jm = PSI.get_jump_model(subproblem)
+                flow_var_p = subproblem.variables[_FLOW_VARIABLE_KEY][l, 1]
+                orig_ub = JuMP.has_upper_bound(flow_var_p) ? JuMP.upper_bound(flow_var_p) : Inf
+                fixed_bins = JuMP.VariableRef[]
+                for v in JuMP.all_variables(jm)
+                    if JuMP.is_binary(v)
+                        bv = round(JuMP.value(v))
+                        JuMP.unset_binary(v)
+                        JuMP.fix(v, bv; force = true)
+                        push!(fixed_bins, v)
+                    end
+                end
+                JuMP.set_upper_bound(flow_var_p, of - _PRICE_TIGHTEN)
+                pstatus = PSI.solve_impl!(subproblem, sys)
+                if pstatus == ISSIM.RunStatus.SUCCESSFULLY_FINALIZED
+                    price = -JuMP.dual(con)
+                end
+                if isfinite(orig_ub)
+                    JuMP.set_upper_bound(flow_var_p, orig_ub)
+                end
+                for v in fixed_bins
+                    JuMP.unfix(v)
+                    JuMP.set_binary(v)
+                end
+            end
+            println("  [update id=$subproblem_id line=$l]  cleared_flow=$(round(of;digits=5))  contribution=$(round(contrib;digits=5))  relief_used=$(round(ru;digits=5))  price=$(round(price;digits=5))")
+
+            if relief !== nothing
+                for d in 1:_NUM_DIRECTIONS
+                    seg_used = Tuple{Int,Float64,Float64,Float64}[]
+                    for s in 1:algo.num_segments
+                        idx = _relief_index(l, s, d)
+                        idx in axes(relief)[1] || continue
+                        var = relief[idx, 1]
+                        ub = JuMP.has_upper_bound(var) ? JuMP.upper_bound(var) : Inf
+                        cost = JuMP.objective_function(PSI.get_jump_model(subproblem)) isa JuMP.GenericAffExpr ?
+                            JuMP.coefficient(JuMP.objective_function(PSI.get_jump_model(subproblem)), var) : NaN
+                        val = JuMP.value(var)
+                        if ub > 1e-9 || val > 1e-9
+                            push!(seg_used, (s, ub, cost, val))
+                        end
+                    end
+                    isempty(seg_used) && continue
+                    println("      [relief segments dir=$d line=$l]  (segment: width=ub, price=cost, taken=value)")
+                    for (s, ub, cost, val) in seg_used
+                        filled = ub > 1e-9 ? round(100 * val / ub; digits=1) : 0.0
+                        println("        seg $s: width=$(round(ub;digits=5))  price=$(round(cost;digits=2))  taken=$(round(val;digits=5))  ($(filled)% full)")
+                    end
+                end
+            end
+        else
+            reason = participates ? "(no flow var)" : "(region not coordinated)"
+            println("  [update id=$subproblem_id line=$l]  $reason  contribution=$(round(contrib;digits=5))")
+        end
+    end
+    return
+end
+
+function apply_coordination!(
+    algo::CostCurveCoordination,
+    container::MultiOptimizationContainer,
+    sys::PSY.System,
+)
+    algo.step_index += 1
+    println("\n################  STEP $(algo.step_index)  ################")
+    # if !isempty(algo.coordinated_regions)
+    #     println("  coordinated_regions = $(algo.coordinated_regions)   N = $(_coordination_N(algo))")
+    # end
+
+    println("--- cleared dispatch (all regions solved) ---")
+    region_ids = sort(collect(keys(container.subproblems)))
+    for l in algo.coordinated_lines
+        for id in region_ids
+            haskey(algo.flow_contribution, (id, l)) || continue
+            contrib = algo.flow_contribution[(id, l)]
+            if haskey(algo.own_flow, (id, l))
+                of = algo.own_flow[(id, l)]
+                ru = get(algo.relief_used, (id, l), 0.0)
+                println("  region $id  cleared_flow=$(round(of;digits=5))  contribution=$(round(contrib;digits=5))  relief_used=$(round(ru;digits=5))")
+            else
+                tag = _is_coordinated_region(algo, id) ? "(no coordination)" : "(region not coordinated)"
+                println("  region $id  $tag  contribution=$(round(contrib;digits=5))")
+            end
+        end
+        contribs = [v for ((r, ln), v) in algo.flow_contribution if ln == l]
+        if !isempty(contribs)
+            total = sum(contribs)
+            cap = PSY.get_rating(PSY.get_component(PSY.MonitoredLine, sys, l))
+            # println("  >>> total actual flow on $l = $(round(total;digits=5))   (capacity = $(round(cap;digits=4)))")
+        end
+    end
+
+    println("--- curve generation ---")
+    for (id, subproblem) in container.subproblems
+        length(PSI.get_time_steps(subproblem)) == 1 || continue
+        _is_coordinated_region(algo, id) || continue
+        coord_lines = _coordinated_lines_in_subproblem(algo, subproblem)
+        isempty(coord_lines) && continue
+        _generate_cost_curves!(algo, subproblem, sys, id, coord_lines)
+    end
+
+    println("--- shadow prices at current flow (NetworkFlowConstraint dual, per clearing region) ---")
+    for l in algo.coordinated_lines
+        sps = [(r, sp) for ((ln, r), sp) in algo.shadow_price if ln == l]
+        if !isempty(sps)
+            parts = join(["region $(r) (cleared) price=$(round(sp;digits=2))" for (r, sp) in sort(sps)], "   ")
+            spread = maximum(sp for (_, sp) in sps) - minimum(sp for (_, sp) in sps)
+            println("  line $l:   $parts")
+        end
+    end
+
+    for (id, subproblem) in container.subproblems
+        length(PSI.get_time_steps(subproblem)) == 1 || continue
+        _is_coordinated_region(algo, id) || continue
+        coord_lines = _coordinated_lines_in_subproblem(algo, subproblem)
+        isempty(coord_lines) && continue
+        _apply_cost_curves!(algo, subproblem, sys, id, coord_lines)
+    end
+    return
+end
+
+function _shift_constraint_constant!(con::JuMP.ConstraintRef, delta::Float64)
+    old = JuMP.normalized_rhs(con)
+    JuMP.set_normalized_rhs(con, old + delta)
+    return
+end
+
+function _generate_cost_curves!(
+    algo::CostCurveCoordination,
+    subproblem::PSI.OptimizationContainer,
+    sys::PSY.System,
+    subproblem_id::String,
+    coord_lines::Vector{String},
+)
+    relief = subproblem.variables[ISOPT.VariableKey(Relief, PSY.MonitoredLine, "")]
+    net_flow_con_array = subproblem.constraints[_NETWORK_FLOW_KEY]
+    segments = 1:algo.num_segments
+    directions = 1:_NUM_DIRECTIONS
+
+    for l in coord_lines
+        net_flow_con = net_flow_con_array[l, 1]
+        for s in segments, d in directions
+            idx = _relief_index(l, s, d)
+            JuMP.set_normalized_coefficient(net_flow_con, relief[idx, 1], 0.0)
+        end
+        off = get(algo.offset, (subproblem_id, l), 0.0)
+        if off != 0.0
+            _shift_constraint_constant!(net_flow_con, +off)
+        end
+    end
+
+    for l in coord_lines
+        algo.cost_curve[(l, subproblem_id)] = _scan_line_curve(algo, subproblem, sys, l, subproblem_id)
+    end
+
+    for l in coord_lines
+        net_flow_con = net_flow_con_array[l, 1]
+        for s in segments, d in directions
+            idx = _relief_index(l, s, d)
+            JuMP.set_normalized_coefficient(net_flow_con, relief[idx, 1], -1.0)
+        end
+        off = get(algo.offset, (subproblem_id, l), 0.0)
+        if off != 0.0
+            _shift_constraint_constant!(net_flow_con, -off)
+        end
+    end
+    return
+end
+
+function _scan_line_curve(
+    algo::CostCurveCoordination,
+    subproblem::PSI.OptimizationContainer,
+    sys::PSY.System,
+    line_name::String,
+    subproblem_id::String,
+)
+    line = PSY.get_component(PSY.MonitoredLine, sys, line_name)
+    capacity = PSY.get_rating(line)
+    check_range = capacity * algo.check_range_rate
+    step = check_range / ((algo.num_segments - 1) / 2)
+
+    flow_var = subproblem.variables[_FLOW_VARIABLE_KEY][line_name, 1]
+    relief_key = ISOPT.VariableKey(Relief, PSY.MonitoredLine, "")
+    # relief_sum = 0.0
+    # if haskey(subproblem.variables, relief_key)
+    #     relief = subproblem.variables[relief_key]
+    #     for d in 1:_NUM_DIRECTIONS, s in 1:algo.num_segments
+    #         idx = _relief_index(line_name, s, d)
+    #         idx in axes(relief)[1] || continue
+    #         relief_sum += JuMP.value(relief[idx, 1])
+    #     end
+    # end
+    # off_cur = get(algo.offset, (subproblem_id, line_name), 0.0)
+    # current_flow = JuMP.value(flow_var) - relief_sum + off_cur
+    # println("generate curve current flow is $(current_flow) ",relief_sum," ",off_cur)
+    current_flow = JuMP.value(flow_var)
+    original_upper_bound = JuMP.upper_bound(flow_var)
+
+    jump_model = PSI.get_jump_model(subproblem)
+    fixed_binaries = JuMP.VariableRef[]
+    for v in JuMP.all_variables(jump_model)
+        if JuMP.is_binary(v)
+            val = JuMP.value(v)
+            JuMP.unset_binary(v)
+            JuMP.fix(v, round(val); force = true)
+            push!(fixed_binaries, v)
+        end
+    end
+
+    raw = Tuple{Float64, Float64, Float64}[]
+    current_cost = NaN
+    current_shadow = 0.0
+    net_flow_con = subproblem.constraints[_NETWORK_FLOW_KEY][line_name, 1]
+    for diff in (-check_range):step:check_range
+        new_ub = current_flow - diff
+        JuMP.set_upper_bound(flow_var, new_ub)
+        status = PSI.solve_impl!(subproblem, sys)
+        if status == ISSIM.RunStatus.SUCCESSFULLY_FINALIZED
+            price = -JuMP.dual(net_flow_con)
+            objv = JuMP.objective_value(jump_model)
+        else
+            price = _INFEASIBLE_COST
+            objv = NaN
+        end
+        push!(raw, (Float64(diff), price, objv))
+        # println("diff is $(diff) $(price) $(objv)")
+        # if abs(diff) < step / 2
+        #     current_cost = objv
+        #     current_shadow = price
+        # end
+    end
+
+    for v in fixed_binaries
+        JuMP.unfix(v)
+        JuMP.set_binary(v)
+    end
+    JuMP.set_upper_bound(flow_var, original_upper_bound)
+
+    algo.shadow_price[(line_name, subproblem_id)] = current_shadow
+
+    points = [(x, y) for (x, y, _) in raw]
+    deduped = _deduplicate_curve(points, algo.num_segments)
+
+    off_dbg = get(algo.offset, (subproblem_id, line_name), 0.0)
+    # println("  region $subproblem_id  cleared_flow=$(round(current_flow;digits=5))  shadow_price@current=$(round(current_shadow;digits=2))  (offset removed=$(round(off_dbg;digits=5)))")
+    # println("      curve (Δflow_reduction, marginal_price, total_cost, Δcost_vs_current):")
+    # for (x, y) in deduped
+    #     objv = NaN
+    #     for (dx, _, dobj) in raw
+    #         if abs(dx - x) < 1e-9
+    #             objv = dobj
+    #             break
+    #         end
+    #     end
+    #     dcost = (isnan(objv) || isnan(current_cost)) ? NaN : objv - current_cost
+    #     println("      Δ=$(round(x;digits=5))  price=$(round(y;digits=2))  total_cost=$(round(objv;digits=2))  Δcost=$(round(dcost;digits=2))")
+    # end
+    return deduped
+end
+
+function _deduplicate_curve(
+    points::Vector{Tuple{Float64, Float64}},
+    max_segments::Int,
+)
+    sorted = sort(points; by = first)
+    seen = Set{Float64}()
+    curve = Tuple{Float64, Float64}[]
+    for (x, y) in sorted
+        y_norm = abs(y) < 1.0e-3 ? 0.0 : round(y; digits = 3)
+        if !(y_norm in seen) && length(curve) < max_segments
+            push!(seen, y_norm)
+            push!(curve, (x, y))
+        end
+    end
+    return curve
+end
+
+function _apply_cost_curves!(
+    algo::CostCurveCoordination,
+    subproblem::PSI.OptimizationContainer,
+    sys::PSY.System,
+    subproblem_id::String,
+    coord_lines::Vector{String},
+)
+    jump_model = PSI.get_jump_model(subproblem)
+    relief = subproblem.variables[ISOPT.VariableKey(Relief, PSY.MonitoredLine, "")]
+    net_flow_con_array = subproblem.constraints[_NETWORK_FLOW_KEY]
+    segments = 1:algo.num_segments
+
+    for l in coord_lines
+        line = PSY.get_component(PSY.MonitoredLine, sys, l)
+        check_range = PSY.get_rating(line) * algo.check_range_rate
+
+        other_curves_with_id = [
+            (other_id, copy(curve))
+            for ((ln, other_id), curve) in algo.cost_curve
+            if ln == l && other_id != subproblem_id &&
+               _is_coordinated_region(algo, other_id)
+        ]
+
+        other_curves = [c for (_, c) in other_curves_with_id]
+        for curve in other_curves
+            push!(curve, (check_range, curve[end][2]))
+        end
+
+        if length(other_curves) > _NUM_DIRECTIONS
+            @warn "Line $l has $(length(other_curves)) contributing subproblems; \
+                   only the first $_NUM_DIRECTIONS will be applied."
+        end
+
+        for (d, (source_id, curve)) in enumerate(other_curves_with_id)
+            d > _NUM_DIRECTIONS && break
+            _apply_curve_to_relief!(jump_model, relief, l, d, curve, segments, check_range)
+            cum = 0.0
+            println("  [relief curve  receiver=$subproblem_id  generated_by=$source_id  line=$l  dir=$d]  (each segment starts at 0, width, price, cumulative reduction)")
+            num_pieces = length(curve)
+            for s in segments
+                width = if s < num_pieces
+                    curve[s + 1][1] - curve[s][1]
+                elseif s == 1 && num_pieces == 1
+                    check_range
+                else
+                    0.0
+                end
+                width <= 1e-9 && continue
+                price = s <= num_pieces ? curve[s][2] : _INFEASIBLE_COST
+                cum += width
+                println("        seg $s: width=$(round(width;digits=5))  price=$(round(price;digits=2))  cumulative=$(round(cum;digits=5))")
+            end
+        end
+
+        N = _coordination_N(algo)
+        net_flow_con = net_flow_con_array[l, 1]
+        old_off = get(algo.offset, (subproblem_id, l), 0.0)
+        new_off = N * check_range
+        if new_off != old_off
+            _shift_constraint_constant!(net_flow_con, -(new_off - old_off))
+        end
+        algo.offset[(subproblem_id, l)] = new_off
+    end
+    return
+end
+
+function _apply_curve_to_relief!(
+    jump_model::JuMP.Model,
+    relief::JuMP.Containers.DenseAxisArray,
+    line_name::String,
+    direction::Int,
+    curve::Vector{Tuple{Float64, Float64}},
+    segments::UnitRange{Int},
+    check_range::Float64,
+)
+    num_pieces = length(curve)
+    for s in segments
+        idx = _relief_index(line_name, s, direction)
+        var = relief[idx, 1]
+        upper = if s < num_pieces
+            curve[s + 1][1] - curve[s][1]
+        elseif s == 1 && num_pieces == 1
+            check_range
+        else
+            0.0
+        end
+        JuMP.set_upper_bound(var, upper)
+        coeff = s <= num_pieces ? curve[s][2] : _INFEASIBLE_COST
+        JuMP.set_objective_coefficient(jump_model, var, coeff)
+    end
+    return
+end

--- a/src/algorithms/coordination/no_coordination.jl
+++ b/src/algorithms/coordination/no_coordination.jl
@@ -1,0 +1,24 @@
+function initialize_coordination!(
+    ::NoCoordination,
+    ::PSI.OptimizationContainer,
+    ::PSY.System,
+)
+    return
+end
+
+function update_coordination!(
+    ::NoCoordination,
+    ::MultiOptimizationContainer,
+    ::PSY.System,
+    ::String,
+)
+    return
+end
+
+function apply_coordination!(
+    ::NoCoordination,
+    ::MultiOptimizationContainer,
+    ::PSY.System,
+)
+    return
+end

--- a/src/algorithms/coordination/shadow_price_coordination.jl
+++ b/src/algorithms/coordination/shadow_price_coordination.jl
@@ -1,0 +1,266 @@
+const _SP_RELIEF_PENALTY = 1.0e7
+const _SP_LOWER_BOUND_RELAXATION = -1.0e4
+const _SP_PRICE_TIGHTEN = 0.00001
+
+const _SP_NETWORK_FLOW_KEY = ISOPT.ConstraintKey(
+    PSI.NetworkFlowConstraint, PSY.MonitoredLine, "",
+)
+const _SP_FLOW_VARIABLE_KEY = ISOPT.VariableKey(
+    PSI.FlowActivePowerVariable, PSY.MonitoredLine, "",
+)
+
+Base.@kwdef mutable struct ShadowPriceCoordination <: CoordinationAlgorithm
+    coordinated_lines::Vector{String}
+    coordinated_regions::Vector{String} = String[]
+    adjust_rate::Float64 = 0.01
+    shadow_price::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    flow_contribution::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    prev_flow_contribution::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    relief_value::Dict{Tuple{String, String}, Float64} =
+        Dict{Tuple{String, String}, Float64}()
+    step_index::Int = 0
+end
+
+_sp_relief_index(line::String) = "$(line)_1"
+
+function _sp_is_coordinated_region(algo::ShadowPriceCoordination, subproblem_id::String)
+    isempty(algo.coordinated_regions) && return true
+    return subproblem_id in algo.coordinated_regions
+end
+
+function _sp_coordinated_lines_in_subproblem(
+    algo::ShadowPriceCoordination,
+    subproblem::PSI.OptimizationContainer,
+)
+    haskey(subproblem.variables, _SP_FLOW_VARIABLE_KEY) || return String[]
+    available = axes(subproblem.variables[_SP_FLOW_VARIABLE_KEY])[1]
+    return [l for l in algo.coordinated_lines if l in available]
+end
+
+function initialize_coordination!(
+    algo::ShadowPriceCoordination,
+    subproblem::PSI.OptimizationContainer,
+    sys::PSY.System,
+)
+    length(PSI.get_time_steps(subproblem)) == 1 || return
+    haskey(subproblem.variables, _SP_FLOW_VARIABLE_KEY) || return
+    haskey(subproblem.constraints, _SP_NETWORK_FLOW_KEY) || return
+
+    coord_lines = _sp_coordinated_lines_in_subproblem(algo, subproblem)
+    isempty(coord_lines) && return
+
+    relief_indices = String[_sp_relief_index(l) for l in coord_lines]
+
+    relief = PSI.add_variable_container!(
+        subproblem,
+        Relief(),
+        PSY.MonitoredLine,
+        relief_indices,
+        PSI.get_time_steps(subproblem);
+        meta = "",
+    )
+
+    jump_model = PSI.get_jump_model(subproblem)
+    flow_array = subproblem.variables[_SP_FLOW_VARIABLE_KEY]
+    net_flow_con_array = subproblem.constraints[_SP_NETWORK_FLOW_KEY]
+
+    for l in coord_lines
+        idx = _sp_relief_index(l)
+        relief[idx, 1] = JuMP.@variable(jump_model, base_name = "Relief_{1,$(l)}")
+        JuMP.set_lower_bound(relief[idx, 1], 0.0)
+        JuMP.set_upper_bound(relief[idx, 1], 0.0)
+        JuMP.set_objective_coefficient(jump_model, relief[idx, 1], _SP_RELIEF_PENALTY)
+    end
+
+    for l in coord_lines
+        flow_var = flow_array[l, 1]
+        net_flow_con = net_flow_con_array[l, 1]
+        JuMP.set_lower_bound(flow_var, _SP_LOWER_BOUND_RELAXATION)
+        idx = _sp_relief_index(l)
+        JuMP.set_normalized_coefficient(net_flow_con, relief[idx, 1], -1.0)
+    end
+    return
+end
+
+function update_coordination!(
+    algo::ShadowPriceCoordination,
+    container::MultiOptimizationContainer,
+    sys::PSY.System,
+    subproblem_id::String,
+)
+    subproblem = get_subproblem(container, subproblem_id)
+    length(PSI.get_time_steps(subproblem)) == 1 || return
+
+    ptdf = PSI.VirtualPTDF(sys; tol = 1e-4, max_cache_size = 10000)
+    bus_numbers = get(container.subproblem_bus_map, subproblem_id, Int[])
+    isempty(bus_numbers) && return
+    bus_balance_expr = PSI.get_expression(subproblem, PSI.ActivePowerBalance(), PSY.ACBus)
+    bus_balance_values = JuMP.value.(bus_balance_expr)
+
+    local_coord_lines = _sp_coordinated_lines_in_subproblem(algo, subproblem)
+    participates = _sp_is_coordinated_region(algo, subproblem_id)
+
+    for l in algo.coordinated_lines
+        contrib = 0.0
+        for bus_no in bus_numbers
+            contrib += ptdf[l, bus_no] * bus_balance_values[bus_no, 1]
+        end
+
+        if haskey(algo.flow_contribution, (subproblem_id, l))
+            algo.relief_value[(subproblem_id, l)] =
+                contrib - algo.flow_contribution[(subproblem_id, l)]
+        else
+            algo.relief_value[(subproblem_id, l)] = 0.0
+        end
+        algo.prev_flow_contribution[(subproblem_id, l)] =
+            get(algo.flow_contribution, (subproblem_id, l), 0.0)
+        algo.flow_contribution[(subproblem_id, l)] = contrib
+
+        if participates && (l in local_coord_lines) &&
+           haskey(subproblem.variables, _SP_FLOW_VARIABLE_KEY) &&
+           l in axes(subproblem.variables[_SP_FLOW_VARIABLE_KEY])[1]
+            flow_var = subproblem.variables[_SP_FLOW_VARIABLE_KEY][l, 1]
+            of = JuMP.value(flow_var)
+            relief_used = 0.0
+            relief_key = ISOPT.VariableKey(Relief, PSY.MonitoredLine, "")
+            if haskey(subproblem.variables, relief_key)
+                relief_arr = subproblem.variables[relief_key]
+                ridx = _sp_relief_index(l)
+                if ridx in axes(relief_arr)[1]
+                    relief_used = JuMP.value(relief_arr[ridx, 1])
+                end
+            end
+
+            price = NaN
+            jm = PSI.get_jump_model(subproblem)
+            cap = PSY.get_rating(PSY.get_component(PSY.MonitoredLine, sys, l))
+            fixed_bins = JuMP.VariableRef[]
+            for v in JuMP.all_variables(jm)
+                if JuMP.is_binary(v)
+                    bv = round(JuMP.value(v))
+                    JuMP.unset_binary(v)
+                    JuMP.fix(v, bv; force = true)
+                    push!(fixed_bins, v)
+                end
+            end
+            JuMP.set_upper_bound(flow_var, cap - _SP_PRICE_TIGHTEN*rand())
+            pstatus = PSI.solve_impl!(subproblem, sys)
+            if pstatus == ISSIM.RunStatus.SUCCESSFULLY_FINALIZED && JuMP.has_upper_bound(flow_var)
+                try
+                    price = -JuMP.dual(JuMP.UpperBoundRef(flow_var))
+                catch
+                    price = NaN
+                end
+            end
+            JuMP.set_upper_bound(flow_var, cap)
+            for v in fixed_bins
+                JuMP.unfix(v)
+                JuMP.set_binary(v)
+            end
+
+            algo.shadow_price[(subproblem_id, l)] = price
+            println("  [sp update id=$subproblem_id line=$l]  cleared_flow=$(round(of;digits=5))  price=$(round(price;digits=5))  relief=$(round(relief_used;digits=5))  contribution=$(round(contrib;digits=5))")
+        else
+            println("  [sp update id=$subproblem_id line=$l]  (not coordinated)  contribution=$(round(contrib;digits=5))")
+        end
+    end
+    return
+end
+
+function apply_coordination!(
+    algo::ShadowPriceCoordination,
+    container::MultiOptimizationContainer,
+    sys::PSY.System,
+)
+    algo.step_index += 1
+    println("\n################  SP STEP $(algo.step_index)  ################")
+
+    region_ids = sort(collect(keys(container.subproblems)))
+
+    for l in algo.coordinated_lines
+        sefl = 0.0
+        for ((id, ln), v) in algo.flow_contribution
+            ln == l && (sefl += v)
+        end
+
+        cap = PSY.get_rating(PSY.get_component(PSY.MonitoredLine, sys, l))
+
+        coord_ids = [id for id in region_ids if _sp_is_coordinated_region(algo, id) &&
+                     haskey(algo.shadow_price, (id, l))]
+        println("--- SP line $l   sefl=$(round(sefl;digits=5))   cap=$(round(cap;digits=4)) ---")
+        prices = [(id, get(algo.shadow_price, (id, l), NaN)) for id in coord_ids]
+        if !isempty(prices)
+            parts = join(["region $(id) price=$(round(p;digits=5))" for (id, p) in prices], "   ")
+            valid = [p for (_, p) in prices if !isnan(p)]
+            spread = length(valid) >= 2 ? maximum(valid) - minimum(valid) : NaN
+            println("  prices:   $parts    (spread = $(round(spread;digits=5)))")
+        end
+
+        for id in coord_ids
+            subproblem = container.subproblems[id]
+            haskey(subproblem.constraints, _SP_NETWORK_FLOW_KEY) || continue
+            l in axes(subproblem.constraints[_SP_NETWORK_FLOW_KEY])[1] || continue
+            relief_key = ISOPT.VariableKey(Relief, PSY.MonitoredLine, "")
+            haskey(subproblem.variables, relief_key) || continue
+            relief = subproblem.variables[relief_key][_sp_relief_index(l), 1]
+
+            own_cost = get(algo.shadow_price, (id, l), 0.0)
+            other_cost = 0.0
+            for other_id in coord_ids
+                other_id == id && continue
+                other_cost = get(algo.shadow_price, (other_id, l), 0.0)
+            end
+
+            own_relief_value = get(algo.relief_value, (id, l), 0.0)
+            other_relief_value = 0.0
+            for other_id in coord_ids
+                other_id == id && continue
+                other_relief_value = get(algo.relief_value, (other_id, l), 0.0)
+            end
+
+            if sefl <= cap + 0.0001 && sefl >= cap - 0.0001
+                if own_cost < other_cost - 0.0001
+                    JuMP.set_upper_bound(relief, 0.0)
+                    JuMP.set_lower_bound(relief, 0.0)
+                elseif own_cost > other_cost + 0.0001
+                    JuMP.set_upper_bound(relief, algo.adjust_rate * cap)
+                    JuMP.set_lower_bound(relief, 0.0)
+                else
+                    JuMP.set_upper_bound(relief, 0.0)
+                    JuMP.set_lower_bound(relief, 0.0)
+                end
+            elseif sefl >= cap + 0.0001
+                if own_cost < other_cost - 0.0001
+                    JuMP.set_upper_bound(relief, 0.0)
+                    JuMP.set_lower_bound(relief, 0.0)
+                elseif own_cost > other_cost + 0.0001
+                    JuMP.set_upper_bound(relief, sefl - cap)
+                    JuMP.set_lower_bound(relief, 0.0)
+                else
+                    JuMP.set_upper_bound(relief, (sefl - cap)/2)
+                    JuMP.set_lower_bound(relief, 0.0)
+                end
+            elseif sefl <= cap - 0.0001
+                if own_cost < other_cost - 0.0001
+                    JuMP.set_upper_bound(relief, 0.0)
+                    JuMP.set_lower_bound(relief, sefl - cap)
+                elseif own_cost > other_cost + 0.0001
+                    JuMP.set_upper_bound(relief, 0.0)
+                    JuMP.set_lower_bound(relief, 0.0)
+                else
+                    JuMP.set_upper_bound(relief, 0.0)
+                    JuMP.set_lower_bound(relief, (sefl - cap)/2)
+                end
+            end
+
+            JuMP.set_objective_coefficient(PSI.get_jump_model(subproblem), relief, other_cost)
+
+            # model_file = "sp_model_step$(algo.step_index)_$(id)_$(l).lp"
+            # JuMP.write_to_file(PSI.get_jump_model(subproblem), model_file)
+        end
+    end
+    return
+end

--- a/src/algorithms/sequential_algorithm.jl
+++ b/src/algorithms/sequential_algorithm.jl
@@ -3,15 +3,16 @@ function build_impl!(
     template::MultiProblemTemplate,
     sys::PSY.System,
 )
+    coordination = get_coordination(container)
     for (index, sub_template) in get_sub_templates(template)
         @info "Building Subproblem $index" _group = PSI.LOG_GROUP_OPTIMIZATION_CONTAINER
-        PSI.build_impl!(get_subproblem(container, index), sub_template, sys)
+        subproblem = get_subproblem(container, index)
+        PSI.build_impl!(subproblem, sub_template, sys)
+        initialize_coordination!(coordination, subproblem, sys)
     end
 
     build_main_problem!(container, template, sys)
-
     check_optimization_container(container)
-
     return
 end
 
@@ -25,32 +26,26 @@ function build_main_problem!(
         subsystem_buses = PSY.get_available_components(PSY.ACBus, sys; subsystem_name=k)
         subsystem_bus_nos = [PSY.get_number(b) for b in subsystem_buses]
         container.subproblem_bus_map[k] = subsystem_bus_nos
-        subsystem_static_injectors =
-            PSY.get_available_components(PSY.StaticInjection, sys; subsystem_name=k)
+        subsystem_static_injectors = PSY.get_available_components(PSY.StaticInjection, sys; subsystem_name=k)
         subsystem_buses = PSY.get_available_components(PSY.ACBus, sys; subsystem_name=k)
         for si in subsystem_static_injectors
             if Symbol(typeof(si)) ∈ device_models_dict
                 if !(PSY.get_bus(si) ∈ subsystem_buses)
-                    throw(
-                        IS.ConflictingInputsError(
-                            "static injector $(PSY.get_name(si)) is in subsystem $k but the bus it is attached to is not. Check your data inputs.",
-                        ),
-                    )
+                    throw(IS.ConflictingInputsError(
+                        "static injector $(PSY.get_name(si)) is in subsystem $k but the bus it is attached to is not. Check your data inputs.",
+                    ))
                 end
             end
         end
-        subsystem_hvdcs =
-            PSY.get_available_components(PSY.TwoTerminalHVDC, sys; subsystem_name=k)
+        subsystem_hvdcs = PSY.get_available_components(PSY.TwoTerminalHVDC, sys; subsystem_name=k)
         if _has_hvdc_model(template)
             for hvdc in subsystem_hvdcs
                 from_bus_no = PSY.get_number(PSY.get_from(PSY.get_arc(hvdc)))
                 to_bus_no = PSY.get_number(PSY.get_to(PSY.get_arc(hvdc)))
                 if (from_bus_no ∉ subsystem_bus_nos) || (to_bus_no ∉ subsystem_bus_nos)
-                    throw(
-                        IS.ConflictingInputsError(
-                            "The terminal buses of HVDC must belong to the same subsystem. Check subsystem assignments for HVDC $(PSY.get_name(hvdc)) belonging to subsystem $k",
-                        ),
-                    )
+                    throw(IS.ConflictingInputsError(
+                        "The terminal buses of HVDC must belong to the same subsystem. Check subsystem assignments for HVDC $(PSY.get_name(hvdc)) belonging to subsystem $k",
+                    ))
                 end
             end
         end
@@ -169,7 +164,7 @@ function solve_impl!(
     container::MultiOptimizationContainer{SequentialAlgorithm},
     sys::PSY.System,
 )
-    # Solve main problem
+    coordination = get_coordination(container)
     status = ISSIM.RunStatus.RUNNING
     for (index, subproblem) in container.subproblems
         @debug "Solving problem $index"
@@ -177,7 +172,12 @@ function solve_impl!(
         if status != ISSIM.RunStatus.SUCCESSFULLY_FINALIZED
             return status
         end
+        update_coordination!(coordination, container, sys, index)
     end
+
     write_results_to_main_container(container)
+
+    apply_coordination!(coordination, container, sys)
+
     return status
 end

--- a/src/core/auxiliary_variables.jl
+++ b/src/core/auxiliary_variables.jl
@@ -1,1 +1,1 @@
-
+struct Relief <: PSI.VariableType end

--- a/src/core/coordination_algorithms.jl
+++ b/src/core/coordination_algorithms.jl
@@ -1,0 +1,14 @@
+abstract type CoordinationAlgorithm end
+
+struct NoCoordination <: CoordinationAlgorithm end
+
+"""
+Initialize coordination for a subproblem during the build phase.
+"""
+function initialize_coordination!(
+    ::CoordinationAlgorithm,
+    ::PSI.OptimizationContainer,
+    ::PSY.System,
+)
+    return
+end

--- a/src/core/coordination_algorithms_methods.jl
+++ b/src/core/coordination_algorithms_methods.jl
@@ -1,0 +1,19 @@
+function update_coordination!(
+    ::CoordinationAlgorithm,
+    ::MultiOptimizationContainer,
+    ::PSY.System,
+    ::String,
+)
+    return
+end
+
+"""
+Apply cross-subproblem coordination after all subproblems have been solved.
+"""
+function apply_coordination!(
+    ::CoordinationAlgorithm,
+    ::MultiOptimizationContainer,
+    ::PSY.System,
+)
+    return
+end

--- a/src/multi_optimization_container.jl
+++ b/src/multi_optimization_container.jl
@@ -22,14 +22,69 @@ Base.@kwdef mutable struct MultiOptimizationContainer{T <: DecompositionAlgorith
     metadata::ISOPT.OptimizationContainerMetadata
     default_time_series_type::Type{<:PSY.TimeSeriesData}  # Maybe isn't needed here
     mpi_info::Union{Nothing, MpiInfo}
+    coordination::CoordinationAlgorithm = NoCoordination()
 end
+
+# function MultiOptimizationContainer(
+#     ::Type{T},
+#     sys::PSY.System,
+#     settings::PSI.Settings,
+#     ::Type{U},
+#     subproblem_keys::Vector{String},
+# ) where {T <: DecompositionAlgorithm, U <: PSY.TimeSeriesData}
+#     resolutions = PSY.get_time_series_resolutions(sys)
+
+#     if length(resolutions) > 1
+#         error(
+#             "Multiple time series resolutions not supported for MultiOptimizationContainer",
+#         )
+#     else
+#         resolution = resolutions[1]
+#     end
+
+#     if isabstracttype(U)
+#         error("Default Time Series Type $U can't be abstract")
+#     end
+
+#     # define dictionary containing the optimization container for the subregion
+#     subproblems = Dict(
+#         k => PSI.OptimizationContainer(sys, settings, nothing, U) for k in subproblem_keys
+#     )
+#     subproblem_bus_map = Dict{String, Vector{Int}}()
+
+#     return MultiOptimizationContainer{T}(;
+#         main_problem=PSI.OptimizationContainer(sys, settings, nothing, U),
+#         subproblems=subproblems,
+#         subproblem_bus_map=subproblem_bus_map,
+#         time_steps=1:1,
+#         resolution=IS.time_period_conversion(resolution),
+#         settings=settings,
+#         variables=Dict{ISOPT.VariableKey, AbstractArray}(),
+#         aux_variables=Dict{ISOPT.AuxVarKey, AbstractArray}(),
+#         duals=Dict{ISOPT.ConstraintKey, AbstractArray}(),
+#         constraints=Dict{ISOPT.ConstraintKey, AbstractArray}(),
+#         objective_function=PSI.ObjectiveFunction(),
+#         expressions=Dict{ISOPT.ExpressionKey, AbstractArray}(),
+#         parameters=Dict{ISOPT.ParameterKey, PSI.ParameterContainer}(),
+#         primal_values_cache=PSI.PrimalValuesCache(),
+#         initial_conditions=Dict{ISOPT.InitialConditionKey, Vector{PSI.InitialCondition}}(),
+#         initial_conditions_data=PSI.InitialConditionsData(),
+#         base_power=PSY.get_base_power(sys),
+#         optimizer_stats=ISOPT.OptimizerStats(),
+#         built_for_recurrent_solves=false,
+#         metadata=ISOPT.OptimizationContainerMetadata(),
+#         default_time_series_type=U,
+#         mpi_info=nothing,
+#     )
+# end
 
 function MultiOptimizationContainer(
     ::Type{T},
     sys::PSY.System,
     settings::PSI.Settings,
     ::Type{U},
-    subproblem_keys::Vector{String},
+    subproblem_keys::Vector{String};
+    coordination::CoordinationAlgorithm = NoCoordination(),
 ) where {T <: DecompositionAlgorithm, U <: PSY.TimeSeriesData}
     resolutions = PSY.get_time_series_resolutions(sys)
 
@@ -74,6 +129,7 @@ function MultiOptimizationContainer(
         metadata=ISOPT.OptimizationContainerMetadata(),
         default_time_series_type=U,
         mpi_info=nothing,
+        coordination = coordination,
     )
 end
 
@@ -113,6 +169,7 @@ PSI.set_time_steps!(container::MultiOptimizationContainer, time_steps::UnitRange
 PSI.get_aux_variables(container::MultiOptimizationContainer) = container.aux_variables
 PSI.get_base_power(container::MultiOptimizationContainer) = container.base_power
 PSI.get_constraints(container::MultiOptimizationContainer) = container.constraints
+get_coordination(container::MultiOptimizationContainer) = container.coordination
 
 function get_subproblem(container::MultiOptimizationContainer, id::String)
     return container.subproblems[id]

--- a/src/multiproblem_template.jl
+++ b/src/multiproblem_template.jl
@@ -235,6 +235,7 @@ function finalize_template!(template::MultiProblemTemplate, sys::PSY.System)
     PSI.finalize_template!(template.base_template, sys)
     for (ix, sub_template) in get_sub_templates(template)
         finalize_template!(sub_template, sys, ix)
+        # PSI.finalize_template!(sub_template, sys)
     end
     return
 end

--- a/src/problems/multi_region_problem.jl
+++ b/src/problems/multi_region_problem.jl
@@ -339,18 +339,18 @@ function PSI._add_feedforward_to_model(
     template = PSI.get_template(sim_model)
     for (id, sub_template) in get_sub_templates(template)
         device_model = PSI.get_model(sub_template, PSI.get_component_type(ff))
-        if device_model === nothing
-            model_name = PSI.get_name(sim_model)
-            throw(
-                IS.ConflictingInputsError(
-                    "Device model $(PSI.get_component_type(ff)) not found in model $model_name",
-                ),
-            )
-        end
         # if device_model === nothing
-        #     @warn "Device model $(PSI.get_component_type(ff)) not in subsystem $id"
-        #     continue   
+        #     model_name = PSI.get_name(sim_model)
+        #     throw(
+        #         IS.ConflictingInputsError(
+        #             "Device model $(PSI.get_component_type(ff)) not found in model $model_name",
+        #         ),
+        #     )
         # end
+        if device_model === nothing
+            @warn "Device model $(PSI.get_component_type(ff)) not in subsystem $id"
+            continue   
+        end
         @info "Attaching $T to $(PSI.get_component_type(ff)) to Template $id"
         PSI.attach_feedforward!(device_model, ff)
     end

--- a/src/problems/multi_region_problem.jl
+++ b/src/problems/multi_region_problem.jl
@@ -4,6 +4,7 @@ function PSI.DecisionModel{MultiRegionProblem}(
     template::MultiProblemTemplate,
     sys::PSY.System,
     ::Union{Nothing, JuMP.Model}=nothing;
+    coordination::CoordinationAlgorithm = NoCoordination(),
     kwargs...,
 )
     name = Symbol(get(kwargs, :name, nameof(MultiRegionProblem)))
@@ -16,6 +17,7 @@ function PSI.DecisionModel{MultiRegionProblem}(
             settings,
             PSI.get_deterministic_time_series_type(sys),
             get_sub_problem_keys(template),
+            coordination = coordination,
         ),
     )
     template_ = deepcopy(template)
@@ -345,6 +347,10 @@ function PSI._add_feedforward_to_model(
                 ),
             )
         end
+        # if device_model === nothing
+        #     @warn "Device model $(PSI.get_component_type(ff)) not in subsystem $id"
+        #     continue   
+        # end
         @info "Attaching $T to $(PSI.get_component_type(ff)) to Template $id"
         PSI.attach_feedforward!(device_model, ff)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,8 @@ using Logging
 include(joinpath(@__DIR__, "test_utils", "system_modifications.jl"))
 include(joinpath(@__DIR__, "test_utils", "model_checks.jl"))
 include(joinpath(@__DIR__, "test_utils", "simulation_runs.jl"))
+include(joinpath(@__DIR__, "test_utils", "coordination_runs.jl"))
+
 
 import Aqua
 Aqua.test_unbound_args(PowerSimulationsDecomposition)

--- a/test/test_coordination.jl
+++ b/test/test_coordination.jl
@@ -1,0 +1,43 @@
+@testset "Coordination algorithms build and execute" begin
+    new_branch_ratings = Dict(
+        "A11" => 1.5,
+        "A28" => 1000.0,
+        "B28" => 1000.0,
+        "CA-1" => 1000.0,
+        "CB-1" => 1000.0,
+        "AB1" => 1000.0,
+        "AB2" => 1000.0,
+        "AB3" => 1000.0,
+        "A18" => 1000.0,
+        "A20" => 1000.0,
+        "A22" => 1000.0,
+    )
+    modeled_monitored_lines = ["A11"]
+
+    sys = build_system(PSISystems, "modified_RTS_GMLC_DA_sys")
+
+    hvdc_bus_area_correction!(sys, x -> x.arc.to.area)
+    add_all_unbounded_interchanges!(sys)
+    set_new_branch_ratings!(sys, new_branch_ratings)
+    convert_to_monitored_line!(sys, modeled_monitored_lines)
+
+    @test run_rts_coordination_simulation(sys, Dict()) == IS.Simulation.RunStatusModule.RunStatus.SUCCESSFULLY_FINALIZED
+
+    @test run_rts_coordination_simulation(
+        sys,
+        Dict(3 => CostCurveCoordination(
+            coordinated_lines = ["A11"],
+            coordinated_regions = ["a", "b"],
+            num_segments = 101,
+            check_range_rate = 0.5,
+        )),
+    ) == IS.Simulation.RunStatusModule.RunStatus.SUCCESSFULLY_FINALIZED
+
+    @test run_rts_coordination_simulation(
+        sys,
+        Dict(3 => ShadowPriceCoordination(
+            coordinated_lines = ["A11"],
+            coordinated_regions = ["a", "b"],
+        )),
+    ) == IS.Simulation.RunStatusModule.RunStatus.SUCCESSFULLY_FINALIZED
+end

--- a/test/test_utils/coordination_runs.jl
+++ b/test/test_utils/coordination_runs.jl
@@ -1,0 +1,376 @@
+struct SubsytemAssignmentData
+    area_subsystem_map::Dict{String, String}
+    branch_assignment_function::Union{Nothing, Function}
+    interchange_lines::Vector{String}
+end
+
+function SubsytemAssignmentData(;
+    area_subsystem_map = Dict{String, String}(),
+    branch_assignment_function = nothing,
+    interchange_lines = String[],
+)
+    return SubsytemAssignmentData(
+        area_subsystem_map,
+        branch_assignment_function,
+        interchange_lines,
+    )
+end
+
+function remove_service_contributing_devices!(sys, bus)
+    for static_injection in get_components(x -> x.bus == bus, StaticInjection, sys)
+        for service in collect(get_services(static_injection))
+            remove_service!(static_injection, service)
+        end
+    end
+end
+
+function hvdc_bus_area_correction!(sys, assignment_function)
+    for hvdc in get_available_components(TwoTerminalHVDC, sys)
+        from_bus = hvdc.arc.from
+        to_bus = hvdc.arc.to
+        from_area = from_bus.area
+        to_area = to_bus.area
+        if from_area != to_area
+            assigned_area = assignment_function(hvdc)
+            if assigned_area == from_area
+                remove_service_contributing_devices!(sys, to_bus)
+                set_area!(to_bus, assigned_area)
+            elseif assigned_area == to_area
+                remove_service_contributing_devices!(sys, from_bus)
+                set_area!(from_bus, assigned_area)
+            else
+                error("HVDC bus area assignment function returned an area different from both terminals")
+            end
+        end
+    end
+end
+
+function add_all_unbounded_interchanges!(sys)
+    areas = collect(get_components(Area, sys))
+    area_names = [get_name(x) for x in areas]
+    areas_sorted = areas[sortperm(area_names)]
+    for i in areas_sorted
+        for j in areas_sorted
+            i_name = get_name(i)
+            j_name = get_name(j)
+            if i_name <= j_name
+                continue
+            end
+            interchange = AreaInterchange(;
+                name = i_name * "_" * j_name,
+                available = true,
+                active_power_flow = 0.0,
+                from_area = i,
+                to_area = j,
+                flow_limits = (from_to = 999999, to_from = 999999),
+            )
+            add_component!(sys, interchange)
+        end
+    end
+end
+
+function set_new_branch_ratings!(sys, branch_rating_dict)
+    for (branch_name, new_rating) in branch_rating_dict
+        l = get_component(ACBranch, sys, branch_name)
+        if !isnothing(l)
+            set_rating!(l, new_rating)
+        end
+    end
+end
+
+function convert_to_monitored_line!(sys, line_names_to_convert)
+    for line_name in line_names_to_convert
+        l = get_component(Line, sys, line_name)
+        if !isnothing(l)
+            convert_component!(sys, l, MonitoredLine)
+        end
+    end
+end
+
+function get_year_from_load_ts(sys::System)
+    load = first(get_components(StaticLoad, sys))
+    ts = get_time_series_array(SingleTimeSeries, load, "max_active_power")
+    tstamps = timestamp(ts)
+    return unique(Dates.year.(tstamps))[1]
+end
+
+function _assign_subsystems!(sys, subsystem_assignment_data)
+    area_subsystem_map = subsystem_assignment_data.area_subsystem_map
+    branch_assignment_function = subsystem_assignment_data.branch_assignment_function
+    subsystems = unique([v for (_, v) in area_subsystem_map])
+    for subsystem in subsystems
+        add_subsystem!(sys, subsystem)
+    end
+    for b in get_components(Area, sys)
+        add_component_to_subsystem!(sys, area_subsystem_map[get_name(b)], b)
+    end
+    for b in get_components(Bus, sys)
+        add_component_to_subsystem!(sys, area_subsystem_map[get_name(get_area(b))], b)
+    end
+    for b in get_components(StaticInjection, sys)
+        add_component_to_subsystem!(sys, area_subsystem_map[get_name(get_area(get_bus(b)))], b)
+    end
+    for b in get_components(Branch, sys)
+        assigned = branch_assignment_function(b, area_subsystem_map)
+        if !isnothing(assigned)
+            for subsystem in assigned
+                PowerSystems.add_component_to_subsystem!(sys, subsystem, b)
+            end
+        end
+    end
+end
+
+function _add_outages!(systems_decisions, system_emulator, outage_vector)
+    return
+end
+
+function make_branch_assignment_function_coord(;
+    coordinated_lines_subsystem_map::Dict{String, Vector{String}},
+    modeled_lines::Vector{String},
+    modeled_monitored_lines::Vector{String},
+)
+    return function (branch, area_map)
+        name = get_name(branch)
+        if isa(branch, MonitoredLine) && haskey(coordinated_lines_subsystem_map, name)
+            return coordinated_lines_subsystem_map[name]
+        elseif isa(branch, MonitoredLine) && name in modeled_monitored_lines
+            to_area = get_name(get_area(get_to(get_arc(branch))))
+            return [area_map[to_area]]
+        elseif isa(branch, Line) && name in modeled_lines
+            return unique(values(area_map))
+        elseif isa(branch, AreaInterchange)
+            return unique(values(area_map))
+        elseif isa(branch, TwoTerminalHVDC)
+            to_area = get_name(get_area(get_to(get_arc(branch))))
+            return [area_map[to_area]]
+        else
+            return nothing
+        end
+    end
+end
+
+function build_multi_stage_simulation_coord(
+    sys::System,
+    decision_templates_in::Vector,
+    emulator_template_in::Union{Nothing, ProblemTemplate},
+    timing::Vector,
+    optimizer;
+    sim_name = "sim",
+    sim_steps = 1,
+    subsystem_assignment_data::Vector{SubsytemAssignmentData} = SubsytemAssignmentData[],
+    feedforwards::Dict{String, Vector{<:PowerSimulations.AbstractAffectFeedforward}} =
+        Dict{String, Vector{<:PowerSimulations.AbstractAffectFeedforward}}(),
+    coordination_per_stage::Dict = Dict{Int, Any}(),
+    initial_time = nothing,
+    simulation_folder = ".",
+)
+    decision_templates = [deepcopy(x) for x in decision_templates_in]
+    emulator_template = deepcopy(emulator_template_in)
+
+    systems_decision = System[]
+    for ix in 1:length(decision_templates)
+        s = deepcopy(sys)
+        transform_single_time_series!(s, timing[ix].horizon, timing[ix].interval)
+        push!(systems_decision, deepcopy(s))
+    end
+
+    system_emulator = nothing
+    if !isnothing(emulator_template)
+        system_emulator = deepcopy(sys)
+        transform_single_time_series!(
+            system_emulator, timing[end].horizon, timing[end].interval,
+        )
+    end
+
+    sa_ix = 1
+    for (template, sysd) in zip(decision_templates, systems_decision)
+        if isa(template, MultiProblemTemplate)
+            _assign_subsystems!(sysd, subsystem_assignment_data[sa_ix])
+            sa_ix += 1
+        end
+    end
+
+    decision_models = DecisionModel[]
+    for (ix, (template, sysd)) in enumerate(zip(decision_templates, systems_decision))
+        if isa(template, MultiProblemTemplate)
+            coord = get(coordination_per_stage, ix, NoCoordination())
+            d = DecisionModel(
+                MultiRegionProblem,
+                template,
+                sysd;
+                name = "D$(ix)",
+                optimizer = optimizer,
+                optimizer_solve_log_print = false,
+                direct_mode_optimizer = true,
+                store_variable_names = true,
+                calculate_conflict = true,
+                initialize_model = false,
+                check_numerical_bounds = false,
+                rebuild_model = false,
+                coordination = coord,
+            )
+        else
+            d = DecisionModel(
+                template,
+                sysd;
+                name = "D$(ix)",
+                optimizer = optimizer,
+                optimizer_solve_log_print = false,
+                direct_mode_optimizer = true,
+                store_variable_names = true,
+                calculate_conflict = true,
+                initialize_model = false,
+                check_numerical_bounds = false,
+                rebuild_model = false,
+            )
+        end
+        push!(decision_models, d)
+    end
+
+    emulation_model = if isnothing(emulator_template)
+        nothing
+    else
+        EmulationModel(
+            emulator_template,
+            system_emulator;
+            name = "EM",
+            optimizer = optimizer,
+            optimizer_solve_log_print = false,
+            direct_mode_optimizer = true,
+            store_variable_names = true,
+            calculate_conflict = true,
+        )
+    end
+
+    models = SimulationModels(;
+        decision_models = decision_models,
+        emulation_model = emulation_model,
+    )
+    sequence = SimulationSequence(;
+        models = models,
+        feedforwards = feedforwards,
+        ini_cond_chronology = InterProblemChronology(),
+    )
+
+    sim = Simulation(;
+        name = sim_name,
+        steps = sim_steps,
+        models = models,
+        sequence = sequence,
+        initial_time = initial_time,
+        simulation_folder = simulation_folder,
+    )
+    build!(sim; console_level = Logging.Info)
+    return sim
+end
+
+function run_rts_coordination_simulation(sys, coordination_per_stage)
+    modeled_monitored_lines = ["A11"]
+    modeled_lines = ["CA-1", "CB-1", "AB1", "A28"]
+    coordinated_line_subsystems = Dict("A11" => ["a", "b"])
+    area_subsystem_map = Dict("1" => "a", "2" => "b", "3" => "c")
+
+    branch_assignment_function_coord = make_branch_assignment_function_coord(;
+        coordinated_lines_subsystem_map = coordinated_line_subsystems,
+        modeled_lines = modeled_lines,
+        modeled_monitored_lines = modeled_monitored_lines,
+    )
+
+    template_full = ProblemTemplate(NetworkModel(AreaPTDFPowerModel; use_slacks = true))
+    template_sub = MultiProblemTemplate(
+        NetworkModel(SplitAreaPTDFPowerModel; use_slacks = true),
+        ["a", "b", "c"],
+    )
+    template_em = ProblemTemplate(NetworkModel(AreaPTDFPowerModel; use_slacks = true))
+
+    for template in [template_full, template_sub, template_em]
+        set_device_model!(template, ThermalStandard, ThermalBasicUnitCommitment)
+        set_device_model!(template, PowerLoad, StaticPowerLoad)
+        set_device_model!(template, DeviceModel(AreaInterchange, StaticBranchUnbounded))
+        set_device_model!(
+            template,
+            DeviceModel(
+                Line,
+                StaticBranchUnbounded;
+                attributes = Dict("filter_function" => x -> get_name(x) in modeled_lines),
+            ),
+        )
+        set_device_model!(template, TwoTerminalGenericHVDCLine, HVDCTwoTerminalLossless)
+    end
+
+    set_device_model!(template_full, DeviceModel(MonitoredLine, StaticBranchUnbounded, use_slacks = true))
+    set_device_model!(template_sub, DeviceModel(MonitoredLine, StaticBranchBounds, use_slacks = true))
+    set_device_model!(template_em, DeviceModel(MonitoredLine, StaticBranchBounds, use_slacks = true))
+
+    timing_em = [
+        (horizon = Hour(24), interval = Hour(24)),
+        (horizon = Hour(24), interval = Hour(24)),
+        (horizon = Hour(1), interval = Hour(1)),
+        (horizon = Hour(1), interval = Hour(1)),
+    ]
+
+    fixed_interchange_flow = FixValueFeedforward(;
+        component_type = AreaInterchange,
+        source = FlowActivePowerVariable,
+        affected_values = [FlowActivePowerVariable],
+    )
+    fixed_hvdc_flow = FixValueFeedforward(;
+        component_type = TwoTerminalGenericHVDCLine,
+        source = FlowActivePowerVariable,
+        affected_values = [FlowActivePowerVariable],
+    )
+    fixed_thermal_on = FixValueFeedforward(;
+        component_type = ThermalStandard,
+        source = OnVariable,
+        affected_values = [OnVariable],
+    )
+    fixed_thermal_dispatch = FixValueFeedforward(;
+        component_type = ThermalStandard,
+        source = ActivePowerVariable,
+        affected_values = [ActivePowerVariable],
+    )
+    feedforwards = Dict{String, Vector{<:PowerSimulations.AbstractAffectFeedforward}}(
+        "D2" => PowerSimulations.AbstractAffectFeedforward[
+            fixed_interchange_flow,
+            fixed_hvdc_flow,
+        ],
+        "D3" => PowerSimulations.AbstractAffectFeedforward[
+            fixed_interchange_flow,
+            fixed_hvdc_flow,
+            fixed_thermal_on,
+        ],
+        "EM" => PowerSimulations.AbstractAffectFeedforward[
+            fixed_hvdc_flow,
+            fixed_thermal_on,
+            fixed_thermal_dispatch,
+        ],
+    )
+
+    year = get_year_from_load_ts(sys)
+    ini_day = DateTime("$year-01-01T00:00:00") + Day(90)
+
+    sim = build_multi_stage_simulation_coord(
+        sys,
+        [template_full, template_sub, template_sub],
+        template_em,
+        timing_em,
+        HiGHS_optimizer_small_gap;
+        sim_name = "rts_test_coord",
+        sim_steps = 1,
+        subsystem_assignment_data = [
+            SubsytemAssignmentData(
+                area_subsystem_map = area_subsystem_map,
+                branch_assignment_function = branch_assignment_function_coord,
+            ),
+            SubsytemAssignmentData(
+                area_subsystem_map = area_subsystem_map,
+                branch_assignment_function = branch_assignment_function_coord,
+            ),
+        ],
+        feedforwards = feedforwards,
+        coordination_per_stage = coordination_per_stage,
+        initial_time = ini_day,
+        simulation_folder = mktempdir(),
+    )
+    return execute!(sim)
+end


### PR DESCRIPTION
Adds a coordination for multi-region decomposition. Implements two methods: CostCurveCoordination and ShadowPriceCoordination. NoCoordination is the default. Includes a test that builds and executes an RTS simulation under all three settings.